### PR TITLE
[22기 최민재] 우체통 생성 오류 수정

### DIFF
--- a/src/components/Nav/PostModal/PostCreateForm.jsx
+++ b/src/components/Nav/PostModal/PostCreateForm.jsx
@@ -96,7 +96,7 @@ const PostCreateForm = () => {
     await axios
       .get(`${POSTBOXES_API}?search=${name}&search_option=exact`)
       .then(res => {
-        if (res.data.results[0].name === name)
+        if (res.data.results[0]?.name === name)
           return alert('우체통 이름이 중복됩니다.');
 
         const limitDay = dayjs().add(7, 'day').format('YYYY-MM-DD');


### PR DESCRIPTION
### 작업 내용

- 우체통 생성 시 이름 중복 체크할 때, 비교할 값이 없으면 오류가 나는 문제 수정